### PR TITLE
chore(release): enable crates.io publishing via release-plz (#2)

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -26,3 +26,4 @@ jobs:
           command: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 description = "Rust SDK for WeChat Agent (iLink Bot) — ported from frostming/weixin-agent-sdk"
 license = "MIT"
+repository = "https://github.com/rararulab/wechat-agent-rs"
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -26,5 +26,5 @@ publish_allow_dirty = false
 # disable running `cargo-semver-checks`
 semver_check = false
 
-# disable cargo publish - not published to crates.io
-publish = false
+# enable cargo publish to crates.io
+publish = true


### PR DESCRIPTION
## Summary
- Set `publish = true` in `release-plz.toml`
- Add `CARGO_REGISTRY_TOKEN` to release workflow
- Add `repository` field to `Cargo.toml` for crates.io metadata

Closes #2

## Test plan
- [ ] Verify `CARGO_REGISTRY_TOKEN` secret is configured in GitHub repo settings
- [ ] Next release PR merge triggers crates.io publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)