### PR TITLE
fix(login): adapt to v2 login API with form-encoded endpoints (#11)

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -100,17 +100,68 @@ impl WeixinApiClient {
         Ok(resp)
     }
 
+    /// Sends a form-encoded POST request and checks the `ret` error field.
+    ///
+    /// Login endpoints use form encoding + `ret`/`err_msg` instead of JSON +
+    /// `errcode`/`errmsg` used by messaging endpoints.
+    async fn post_form(&self, path: &str, params: &[(&str, &str)]) -> Result<Value> {
+        self.post_form_with_timeout(path, params, Duration::from_secs(30))
+            .await
+    }
+
+    /// Same as [`post_form`](Self::post_form) but with a custom timeout.
+    async fn post_form_with_timeout(
+        &self,
+        path: &str,
+        params: &[(&str, &str)],
+        timeout: Duration,
+    ) -> Result<Value> {
+        let url = format!("{}/{}", self.base_url, path);
+        let resp = self
+            .client
+            .post(&url)
+            .headers(self.headers())
+            .form(params)
+            .timeout(timeout)
+            .send()
+            .await
+            .context(HttpSnafu)?
+            .json::<Value>()
+            .await
+            .context(HttpSnafu)?;
+
+        if let Some(ret) = resp.get("ret").and_then(Value::as_i64)
+            && ret != 0
+        {
+            let msg = resp
+                .get("err_msg")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown error")
+                .to_string();
+            return Err(ApiSnafu {
+                code:    ret,
+                message: msg,
+            }
+            .build());
+        }
+        Ok(resp)
+    }
+
     /// Requests a new login QR code from the API.
     pub async fn fetch_qr_code(&self) -> Result<Value> {
-        self.post("ilink/bot/get_bot_qrcode", &serde_json::json!({}))
+        self.post_form("ilink/bot/get_bot_qrcode", &[("bot_type", "3")])
             .await
     }
 
     /// Polls the current scan status for the given `qrcode_id`.
+    ///
+    /// Uses a longer timeout than the default because this endpoint
+    /// long-polls until the user scans the QR code.
     pub async fn get_qr_code_status(&self, qrcode_id: &str) -> Result<Value> {
-        self.post(
+        self.post_form_with_timeout(
             "ilink/bot/get_qrcode_status",
-            &serde_json::json!({ "qrcode_id": qrcode_id }),
+            &[("qrcode", qrcode_id), ("bot_type", "3")],
+            Duration::from_secs(60),
         )
         .await
     }

--- a/src/api.rs
+++ b/src/api.rs
@@ -141,7 +141,7 @@ impl WeixinApiClient {
                 .unwrap_or("unknown error")
                 .to_string();
             return Err(ApiSnafu {
-                code: ret,
+                code:    ret,
                 message: msg,
             }
             .build());

--- a/src/api.rs
+++ b/src/api.rs
@@ -13,9 +13,9 @@ const SESSION_EXPIRED_ERRCODE: i64 = -14;
 /// Handles authentication headers, request signing, and automatic
 /// session-expiry detection on every response.
 pub struct WeixinApiClient {
-    client:    Client,
-    base_url:  String,
-    token:     String,
+    client: Client,
+    base_url: String,
+    token: String,
     route_tag: Option<String>,
 }
 
@@ -32,7 +32,9 @@ impl WeixinApiClient {
     }
 
     /// Replaces the bearer token used for subsequent requests.
-    pub fn set_token(&mut self, token: &str) { self.token = token.to_string(); }
+    pub fn set_token(&mut self, token: &str) {
+        self.token = token.to_string();
+    }
 
     fn headers(&self) -> reqwest::header::HeaderMap {
         use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
@@ -139,7 +141,7 @@ impl WeixinApiClient {
                 .unwrap_or("unknown error")
                 .to_string();
             return Err(ApiSnafu {
-                code:    ret,
+                code: ret,
                 message: msg,
             }
             .build());

--- a/src/api.rs
+++ b/src/api.rs
@@ -13,9 +13,9 @@ const SESSION_EXPIRED_ERRCODE: i64 = -14;
 /// Handles authentication headers, request signing, and automatic
 /// session-expiry detection on every response.
 pub struct WeixinApiClient {
-    client: Client,
-    base_url: String,
-    token: String,
+    client:    Client,
+    base_url:  String,
+    token:     String,
     route_tag: Option<String>,
 }
 
@@ -32,9 +32,7 @@ impl WeixinApiClient {
     }
 
     /// Replaces the bearer token used for subsequent requests.
-    pub fn set_token(&mut self, token: &str) {
-        self.token = token.to_string();
-    }
+    pub fn set_token(&mut self, token: &str) { self.token = token.to_string(); }
 
     fn headers(&self) -> reqwest::header::HeaderMap {
         use reqwest::header::{HeaderMap, HeaderName, HeaderValue};

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -26,11 +26,9 @@ pub async fn login(options: LoginOptions) -> Result<String> {
         .context(LoginFailedSnafu {
             reason: "no qrcode_img_content in response",
         })?;
-    let qrcode_id = qr_resp["qrcode"]
-        .as_str()
-        .context(LoginFailedSnafu {
-            reason: "no qrcode in response",
-        })?;
+    let qrcode_id = qr_resp["qrcode"].as_str().context(LoginFailedSnafu {
+        reason: "no qrcode in response",
+    })?;
 
     let qr = qrcode::QrCode::new(qrcode_url.as_bytes()).map_err(|e| {
         LoginFailedSnafu {
@@ -85,10 +83,10 @@ pub async fn login(options: LoginOptions) -> Result<String> {
                     .to_string();
 
                 let account_data = storage::AccountData {
-                    token:    token.to_string(),
+                    token: token.to_string(),
                     saved_at: chrono::Utc::now().to_rfc3339(),
                     base_url: base.to_string(),
-                    user_id:  user_id.to_string(),
+                    user_id: user_id.to_string(),
                 };
                 storage::save_account_data(&account_id, &account_data)?;
 

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -83,10 +83,10 @@ pub async fn login(options: LoginOptions) -> Result<String> {
                     .to_string();
 
                 let account_data = storage::AccountData {
-                    token: token.to_string(),
+                    token:    token.to_string(),
                     saved_at: chrono::Utc::now().to_rfc3339(),
                     base_url: base.to_string(),
-                    user_id: user_id.to_string(),
+                    user_id:  user_id.to_string(),
                 };
                 storage::save_account_data(&account_id, &account_data)?;
 

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -21,15 +21,15 @@ pub async fn login(options: LoginOptions) -> Result<String> {
     let client = WeixinApiClient::new(base_url, "", None);
 
     let qr_resp = client.fetch_qr_code().await?;
-    let qrcode_url = qr_resp["data"]["qrcode_url"]
+    let qrcode_url = qr_resp["qrcode_img_content"]
         .as_str()
         .context(LoginFailedSnafu {
-            reason: "no qrcode_url",
+            reason: "no qrcode_img_content in response",
         })?;
-    let qrcode_id = qr_resp["data"]["qrcode_id"]
+    let qrcode_id = qr_resp["qrcode"]
         .as_str()
         .context(LoginFailedSnafu {
-            reason: "no qrcode_id",
+            reason: "no qrcode in response",
         })?;
 
     let qr = qrcode::QrCode::new(qrcode_url.as_bytes()).map_err(|e| {
@@ -49,7 +49,11 @@ pub async fn login(options: LoginOptions) -> Result<String> {
     loop {
         tokio::time::sleep(std::time::Duration::from_secs(2)).await;
         let status_resp = client.get_qr_code_status(qrcode_id).await?;
-        let status = status_resp["data"]["status"].as_str().unwrap_or("unknown");
+        // Try top-level field first (v2 API), fall back to nested data.status (v1)
+        let status = status_resp["status"]
+            .as_str()
+            .or_else(|| status_resp["data"]["status"].as_str())
+            .unwrap_or("unknown");
 
         match status {
             "wait" => {}
@@ -60,7 +64,12 @@ pub async fn login(options: LoginOptions) -> Result<String> {
                 return Err(QrCodeExpiredSnafu.build());
             }
             "confirmed" => {
-                let data = &status_resp["data"];
+                // v2 API returns credentials at top level; v1 nests under data
+                let data = if status_resp.get("bot_token").is_some() {
+                    &status_resp
+                } else {
+                    &status_resp["data"]
+                };
                 let token = data["bot_token"].as_str().context(LoginFailedSnafu {
                     reason: "no bot_token",
                 })?;


### PR DESCRIPTION
Closes #11

## Summary

参考 https://github.com/rararulab/rara/pull/842，微信 iLink Bot 登录 API 发生了变更：

- **api.rs**: 新增 `post_form` / `post_form_with_timeout` 方法，登录接口从 JSON 编码改为 form 编码，错误检查从 `errcode`/`errmsg` 改为 `ret`/`err_msg`
- **bot.rs**: QR code 响应字段路径更新（`qrcode_img_content`, `qrcode`），状态轮询和凭证提取兼容 v1/v2 两种 API 格式

## Test plan

- [x] `cargo check` 通过
- [x] `cargo test` — 37 tests 全部通过
- [x] `cargo clippy --all-targets --all-features -- -D warnings` 无警告
- [ ] 实际微信扫码登录验证